### PR TITLE
Extension needs to be declared as a `type` import

### DIFF
--- a/src/one-dark.ts
+++ b/src/one-dark.ts
@@ -1,5 +1,5 @@
 import {EditorView} from "@codemirror/view"
-import {Extension} from "@codemirror/state"
+import {type Extension} from "@codemirror/state"
 import {HighlightStyle, syntaxHighlighting} from "@codemirror/language"
 import {tags as t} from "@lezer/highlight"
 


### PR DESCRIPTION
Without this, the build will include `Extension` in the output, which, when used with esm.run (or any other CDN), this theme loads a separate copy of `@codemirror/state`, which gets the error about instanceof checks with multiple states loaded.

In general, type imports are a good signal to the compiler for stripping imports out during builds _and_ help out humans know what the intend of imports are :partying_face:


Here is a reproduction of the problem being fixed: https://jsbin.com/sacumiraju/1/edit?html,output (currently only works in chrome due to import map support)