### PR TITLE
update readme

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -19,6 +19,19 @@ we have a [code of
 conduct](http://contributor-covenant.org/version/1/1/0/) that applies
 to communication around the project.
 
+# Usage
+```bash
+npm install @codemirror/theme-one-dark
+```
+
+```js
+import { oneDark } from '@codemirror/theme-one-dark'
+
+const editor = new EditorView({
+  extensions: [oneDark]
+})
+```
+
 ## API Reference
 
 @oneDark


### PR DESCRIPTION
This fixes the need to search docs and forums for an example on how to use the `theme-one-dark` theme.